### PR TITLE
[trod][7] - Fix pokemon id range

### DIFF
--- a/src/utils/getRandomPokemonId.ts
+++ b/src/utils/getRandomPokemonId.ts
@@ -1,5 +1,5 @@
 const LAST_POKEMON_ID: number = 1_010;
 
 export const getRandomPokemonId = (): number => {
-  return Math.floor(Math.random() * LAST_POKEMON_ID);
+  return Math.floor(Math.random() * LAST_POKEMON_ID + 1);
 };


### PR DESCRIPTION
`getRandomPokemonId` was generating IDs from 0-1,010 which broke the app since there are no Pokemon with id 0. The function now gets ids from 1-1,010.